### PR TITLE
Separate Rust Twig and Twig licenses, fixes #3

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -1,0 +1,4 @@
+Rust version of Twig was developed by:
+
+Colin Kiegel <kiegel@gmx.de>
+Nerijus Arlauskas <nercury@gmail.com>

--- a/COPYRIGHT
+++ b/COPYRIGHT
@@ -1,0 +1,39 @@
+The Rust Twig Project is copyright 2015, The Rust Twig Team,
+developers listed in AUTHORS.txt.
+
+Full license contents are in LICENSE file.
+
+Rust Twig Project would not have been possible without original
+Twig:
+
+    Copyright (c) 2009-2014 by the Twig Team.
+
+    Some rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are
+    met:
+
+        * Redistributions of source code must retain the above copyright
+          notice, this list of conditions and the following disclaimer.
+
+        * Redistributions in binary form must reproduce the above
+          copyright notice, this list of conditions and the following
+          disclaimer in the documentation and/or other materials provided
+          with the distribution.
+
+        * The names of the contributors may not be used to endorse or
+          promote products derived from this software without specific
+          prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+    A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+    OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+    SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+    LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+    DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+    THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2009-2014 by the Twig Team.
+Copyright (c) 2015 by the Rust Twig Team.
 
 Some rights reserved.
 


### PR DESCRIPTION
I used as an example the Rust project itself. Basically, I created `Rust Twig Team` license and included `Twig Team` license in `COPYRIGHT` file.

Let me know what you think.
