### PR TITLE
use https://crates.io/crates/quick-error/

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,11 @@
 [package]
-name = "twig"
-version = "0.1.0"
+authors = ["Rust Twig Team", "Nerijus Arlauskas <nercury@gmail.com>", "Colin Kiegel <kiegel@gmx.de>"]
 description = "Twig templating engine for Rust; work in progress."
 documentation = ""
-repository = "https://github.com/rust-web/twig"
-authors = [
-    "Rust Twig Team",
-    "Nerijus Arlauskas <nercury@gmail.com>",
-    "Colin Kiegel <kiegel@gmx.de>"
-]
 license = "BSD-3-Clause"
+name = "twig"
+repository = "https://github.com/rust-web/twig"
+version = "0.1.0"
+
+[dependencies]
+quick-error = "0.*"

--- a/src/engine/error.rs
+++ b/src/engine/error.rs
@@ -6,7 +6,6 @@
 //! Typisation of syntax errors.
 
 use std::error::Error;
-use std::fmt::{self, Display};
 use std::convert::From;
 
 pub type LoaderError = Box<Error>; // unimplemented!()
@@ -14,61 +13,32 @@ pub type ParserError = Box<Error>; // unimplemented!()
 pub type LexerError = Box<Error>; // unimplemented!()
 pub type ExtensionRegistryError = Box<Error>; // unimplemented!()
 
-
-#[derive(Debug)]
-pub enum TwigError {
-    Loader(LoaderError),
-    Lexer(LexerError),
-    Parser(ParserError),
-    ExtensionRegistry(ExtensionRegistryError),
-}
-
-impl From<LoaderError> for TwigError {
-    fn from(err: LoaderError) -> TwigError {
-        TwigError::Loader(err)
-    }
-}
-
-// Due to the `dummy` error impls we can not define different From-impls
-//
-// impl From<LexerError> for TwigError {
-//     fn from(err: LexerError) -> TwigError {
-//         TwigError::Lexer(err)
-//     }
-// }
-//
-// impl From<ParserError> for TwigError {
-//     fn from(err: ParserError) -> TwigError {
-//         TwigError::Parser(err)
-//     }
-// }
-//
-// impl From<ExtensionRegistryError> for TwigError {
-//     fn from(err: ExtensionRegistryError) -> TwigError {
-//         TwigError::ExtensionRegistry(err)
-//     }
-// }
-
-impl Error for TwigError {
-    fn description(&self) -> &str {
-        match *self {
-            TwigError::Loader(..) => "Twig loader error.",
-            TwigError::Lexer(..) => "Twig lexer error.",
-            TwigError::Parser(..) => "Twig parser error.",
-            TwigError::ExtensionRegistry(..) => "Twig extension registry error."
+quick_error! {
+    #[derive(Debug)]
+    pub enum TwigError {
+        Loader(cause: LoaderError) {
+            description("Twig loader error")
+            display(me) -> ("{}: {}", me.description(), cause)
+            from()
+            cause(cause.as_ref())
         }
-    }
-}
-
-impl Display for TwigError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        try!(write!(f, "{}", self.description()));
-
-        match *self {
-            TwigError::Loader(ref e) => Display::fmt(e,f),
-            TwigError::Lexer(ref e) => Display::fmt(e,f),
-            TwigError::Parser(ref e) => Display::fmt(e,f),
-            TwigError::ExtensionRegistry(ref e) => Display::fmt(e,f),
+        Lexer(cause: LexerError) {
+            description("Twig lexer error")
+            display(me) -> ("{}: {}", me.description(), cause)
+            //from()
+            cause(cause.as_ref())
+        }
+        Parser(cause: ParserError) {
+            description("Twig parser error")
+            display(me) -> ("{}: {}", me.description(), cause)
+            //from()
+            cause(cause.as_ref())
+        }
+        ExtensionRegistry(cause: ExtensionRegistryError) {
+            description("Twig extension registry error")
+            display(me) -> ("{}: {}", me.description(), cause)
+            //from()
+            cause(cause.as_ref())
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,6 +59,8 @@
 //! [changelog]: https://github.com/rust-web/twig/blob/master/CHANGELOG.md
 //! [twigphp]: http://twig.sensiolabs.org/documentation
 
+#[macro_use] extern crate quick_error;
+
 #[macro_use] pub mod api;
 pub mod engine;
 


### PR DESCRIPTION
I just found this ingenious library: https://github.com/tailhook/quick-error
This should remove a lot of boilerplate from error definitions. Just what I was dreaming of. ^^

PS - Found it here: https://this-week-in-rust.org/blog/2015/12/14/this-week-in-rust-109/
